### PR TITLE
write coordinates from original OEMol, not via parmed

### DIFF
--- a/ffcompare.py
+++ b/ffcompare.py
@@ -27,7 +27,6 @@
 # - Smirff99Frosst
 
 ### To do / Ideas:
-# CONVERT OPENMM COORDINATES TO ANGSTROMS
 # Have a common function to write out ofs from the updated mol. for ALL ffs.
 # Instead of having a different boolean variable for every FF (since right now
 #  the user can only specify one at a time anyway), we could use index args.


### PR DESCRIPTION
- for anything that goes through OpenMM, load coordinates back into original OEMol for writing
- restructure ffcompare (dogaff, dosmirff) exceptions inside load_and_minimize function
- updated description of script and most of the option parser descriptions
  ( still need to update documentation!! )
- changed function parameter of prmDir and inpDir to just parameter specifying the directory specifying GAFFx-dependencies
- fixed variable name mfmol --> mf1mol
- removed the commented out GAFF2 section (GAFFx should handle both)



