### PR TITLE
Changed size of prmtop and inpcrd for GAFF2

### DIFF
--- a/min_oe_openMM.py
+++ b/min_oe_openMM.py
@@ -207,7 +207,7 @@ def optGAFFx(mol, gaffdir, output_mol2, log):
     if not os.path.exists(prmFile):
         log.write("%s does not exist, skipping minimization\n" % prmFile)
         return False
-    elif not os.path.getsize(prmFile) > 0:
+    elif not os.path.getsize(prmFile) > 40:
         log.write("%s is empty, skipping minimization\n" % prmFile)
         return False
 
@@ -215,7 +215,7 @@ def optGAFFx(mol, gaffdir, output_mol2, log):
     if not os.path.exists(inpFile):
         log.write("%s does not exist, skipping minimization\n" % inpFile)
         return False
-    elif not os.path.getsize(inpFile):
+    elif not os.path.getsize(inpFile) > 40:
         log.write("%s is empty, skipping minimization\n" % inpFile)
         return False
 


### PR DESCRIPTION
Skip files that are smaller than 40 bytes for GAFF2
These files were the result of unsuccessful attempts to make prmtop & inpcrd files using genMOL2.py 
From analysis of eMolecules_1 and Drugbank, the smallest file appears to be 23 bytes, and the largest at 31 bytes
Currently, 40 bytes seem to be working for Drugbank & eMolecules_1