### PR TITLE
Fixing genMOL2.py typo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following is a list of the force fields being considered here:
 |MDTRAJ               | 1.7.2     |
 |ParmEd               | 2.6.1     |
 |OpenForceField       | 0.1.6     |
+|Schrodinger          | 2017-2    |
 
 ### Contents
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ The following is a list of the force fields being considered here:
 |MDTRAJ               | 1.7.2     |
 |ParmEd               | 2.6.1     |
 |OpenForceField       | 0.1.6     |
-|Schrodinger          | 2017-2    |
+|Schrodinger          | 2017-2  \*|
+
+\* We are working on updating this code to support the open source Desmond package provided by D.E. Shaw
 
 ### Contents
 

--- a/genMOL2.py
+++ b/genMOL2.py
@@ -83,7 +83,7 @@ def GenTriposGAFF(mol):
         os.system('antechamber -i %s/%s.mol2 -fi mol2 -o %s/%s.mol2 -fo mol2 -at gaff2'\
          % ('tripos_mol2', molName, 'gaff2_mol2', molName))
         os.system('parmchk2 -i %s/%s.mol2 -f mol2 -s gaff2 -o %s/%s.frcmod'\
-         % ('gaff_mol2', molName, 'gaff2_mol2', molName))
+         % ('gaff2_mol2', molName, 'gaff2_mol2', molName))
 
         # generates gaff2 inpcrd and prmtop files
         try:


### PR DESCRIPTION
Fixing a typo in genMOL2.py. This typo caused the low ouput of GAFF2 in the past. The fixed code seems to produce a much higher and more accurate output. 